### PR TITLE
Add `init_state()` method to all fm97 channels

### DIFF
--- a/jaxley_mech/channels/fm97.py
+++ b/jaxley_mech/channels/fm97.py
@@ -195,8 +195,8 @@ class KA(Channel):
         alpha_a, beta_a = KA.A_gate(voltages)
         alpha_ha, beta_ha = KA.hA_gate(voltages)
         return {
-            f"{prefix}_a": alpha_a / (alpha_a + beta_a),
-            f"{prefix}_ha": alpha_ha / (alpha_ha + beta_ha),
+            f"{prefix}_A": alpha_a / (alpha_a + beta_a),
+            f"{prefix}_hA": alpha_ha / (alpha_ha + beta_ha),
         }
 
     @staticmethod

--- a/tests/test_init_state.py
+++ b/tests/test_init_state.py
@@ -1,0 +1,30 @@
+import numpy as np
+from jaxley_mech.channels.fm97 import Na, K, KA, Leak, Ca, KCa
+import pytest
+
+@pytest.mark.parametrize("channel_class", [Na, K, KA, Leak, Ca, KCa])
+def test_init_state(channel_class):
+    """Test whether, if the channels are initialized in fixed point, they do not change.
+    """
+    voltages = -65.0
+    dt = 0.025
+
+    channel = channel_class()
+    init_state = channel.init_state(voltages, channel.channel_params)
+
+    # Deal with adding potentially missing states (which have no init).
+    updated_states = channel.channel_states
+    for key, val in init_state.items():
+        updated_states[key] = val
+    updated_states[f"{channel._name}_current"] = 0.0
+
+    # Add radius and length for those channels that rely on it (e.g. Ca).
+    params = channel.channel_params
+    params["radius"] = 1.0
+    params["length"] = 1.0
+
+    new_states = channel.update_states(updated_states, dt, voltages, params)
+
+    # Channel states should not have changed.
+    for key in init_state.keys():
+        assert np.max(np.abs(new_states[key] - init_state[key])) < 1e-8


### PR DESCRIPTION
This adds a `init_state()` method to all channels. Note that `init_state` does not have to return a value for all states (e.g. `Ca.Ca_vCA` which has no closed form). For those channels, I am planning to automatically run a voltage clamp to initialize them properly, but for now I will simply keep them at their initial value.