### PR TITLE
`jnp.exp` to `save_exp`

### DIFF
--- a/jaxley_mech/channels/benison.py
+++ b/jaxley_mech/channels/benison.py
@@ -2,7 +2,11 @@ from typing import Dict, Optional
 
 import jax.numpy as jnp
 from jaxley.channels import Channel
-from jaxley.solver_gate import solve_gate_exponential, solve_inf_gate_exponential
+from jaxley.solver_gate import (
+    save_exp,
+    solve_gate_exponential,
+    solve_inf_gate_exponential,
+)
 
 from ..utils import efun
 
@@ -101,14 +105,14 @@ class Na(Channel):
 
     @staticmethod
     def m_gate(v):
-        alpha = 0.5 * (v + 29.0) / (1 - jnp.exp(-0.18 * (v + 29.0)) + 1e-6)
-        beta = 6.0 * jnp.exp(-(v + 45.0) / 15.0)
+        alpha = 0.5 * (v + 29.0) / (1 - save_exp(-0.18 * (v + 29.0)) + 1e-6)
+        beta = 6.0 * save_exp(-(v + 45.0) / 15.0)
         return alpha, beta
 
     @staticmethod
     def h_gate(v):
-        alpha = 0.15 * jnp.exp(-(v + 47.0) / 20.0)
-        beta = 2.8 / (1.0 + jnp.exp(-0.1 * (v + 20.0)))
+        alpha = 0.15 * save_exp(-(v + 47.0) / 20.0)
+        beta = 2.8 / (1.0 + save_exp(-0.1 * (v + 20.0)))
         return alpha, beta
 
 
@@ -157,8 +161,8 @@ class Kdr(Channel):
 
     @staticmethod
     def m_gate(v):
-        alpha = 0.0065 * (v + 30) / (1.0 - jnp.exp(-0.3 * v))
-        beta = 0.083 * jnp.exp((v + 15.0) / 15.0)
+        alpha = 0.0065 * (v + 30) / (1.0 - save_exp(-0.3 * v))
+        beta = 0.083 * save_exp((v + 15.0) / 15.0)
         return alpha, beta
 
 
@@ -213,13 +217,13 @@ class KA(Channel):
 
     @staticmethod
     def m_gate(v):
-        alpha = 0.02 * (v + 15) / (1 - jnp.exp(-0.12 * (v + 15)) + 1e-6)
-        beta = 0.05 * jnp.exp(-(v + 1.0) / 30.0)
+        alpha = 0.02 * (v + 15) / (1 - save_exp(-0.12 * (v + 15)) + 1e-6)
+        beta = 0.05 * save_exp(-(v + 1.0) / 30.0)
         return alpha, beta
 
     @staticmethod
     def h_gate(v):
-        h_inf = 1.0 / (1.0 + jnp.exp((v + 62.0) / 6.35))
+        h_inf = 1.0 / (1.0 + save_exp((v + 62.0) / 6.35))
         return h_inf
 
 
@@ -274,8 +278,8 @@ class CaL(Channel):
 
     @staticmethod
     def m_gate(v):
-        alpha = 0.061 * (v - 3.0) / (1.0 - jnp.exp(-(v - 3.0) / 12.5))
-        beta = 0.058 * jnp.exp(-(v - 10.0) / 15.0)
+        alpha = 0.061 * (v - 3.0) / (1.0 - save_exp(-(v - 3.0) / 12.5))
+        beta = 0.058 * save_exp(-(v - 10.0) / 15.0)
         return alpha, beta
 
 
@@ -330,14 +334,14 @@ class CaN(Channel):
 
     @staticmethod
     def m_gate(v):
-        alpha = 0.1 * (v - 20.0) / (1.0 - jnp.exp(-0.1 * (v - 20.0)) + 1e-6)
-        beta = 0.4 * jnp.exp(-(v + 25.0) / 18.0)
+        alpha = 0.1 * (v - 20.0) / (1.0 - save_exp(-0.1 * (v - 20.0)) + 1e-6)
+        beta = 0.4 * save_exp(-(v + 25.0) / 18.0)
         return alpha, beta
 
     @staticmethod
     def h_gate(v):
-        alpha = 0.01 * jnp.exp(-(v + 50.0) / 10.0)
-        beta = 0.1 / (1.0 + jnp.exp(-(v + 17.0) / 17.0))
+        alpha = 0.01 * save_exp(-(v + 50.0) / 10.0)
+        beta = 0.1 / (1.0 + save_exp(-(v + 17.0) / 17.0))
         return alpha, beta
 
 

--- a/jaxley_mech/channels/fm97.py
+++ b/jaxley_mech/channels/fm97.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 import jax.numpy as jnp
 from jax.lax import select
 from jaxley.channels import Channel
-from jaxley.solver_gate import solve_gate_exponential
+from jaxley.solver_gate import save_exp, solve_gate_exponential
 
 from ..utils import efun
 
@@ -104,13 +104,13 @@ class Na(Channel):
     @staticmethod
     def m_gate(v):
         alpha = 0.6 * efun(-(v + 30), 10.0)
-        beta = 20.0 * jnp.exp(-(v + 55.0) / 18.0)
+        beta = 20.0 * save_exp(-(v + 55.0) / 18.0)
         return alpha, beta
 
     @staticmethod
     def h_gate(v):
-        alpha = 0.4 * jnp.exp(-(v + 50.0) / 20.0)
-        beta = 6.0 / (1.0 + jnp.exp(-0.1 * (v + 20.0)))
+        alpha = 0.4 * save_exp(-(v + 50.0) / 20.0)
+        beta = 6.0 / (1.0 + save_exp(-0.1 * (v + 20.0)))
         return alpha, beta
 
 
@@ -160,7 +160,7 @@ class K(Channel):
     @staticmethod
     def n_gate(v):
         alpha = 0.02 * efun(-(v + 40), 10)
-        beta = 0.4 * jnp.exp(-(v + 50) / 80)
+        beta = 0.4 * save_exp(-(v + 50) / 80)
         return alpha, beta
 
 
@@ -214,13 +214,13 @@ class KA(Channel):
     @staticmethod
     def A_gate(v):
         alpha = 0.006 * efun(-(v + 90), 1)
-        beta = 0.1 * jnp.exp(-(v + 30) / 10)
+        beta = 0.1 * save_exp(-(v + 30) / 10)
         return alpha, beta
 
     @staticmethod
     def hA_gate(v):
-        alpha = 0.04 * jnp.exp(-(v + 70) / 20)
-        beta = 0.6 / (1.0 + jnp.exp(-(v + 40) / 10))
+        alpha = 0.04 * save_exp(-(v + 70) / 20)
+        beta = 0.6 / (1.0 + save_exp(-(v + 40) / 10))
         return alpha, beta
 
 
@@ -306,7 +306,7 @@ class Ca(Channel):
     @staticmethod
     def c_gate(v):
         alpha = 0.3 * efun(-(v + 13), 10)
-        beta = 10 * jnp.exp(-(v + 38) / 18)
+        beta = 10 * save_exp(-(v + 38) / 18)
         return alpha, beta
 
 

--- a/jaxley_mech/channels/hh.py
+++ b/jaxley_mech/channels/hh.py
@@ -2,7 +2,7 @@ from typing import Dict, Optional
 
 import jax.numpy as jnp
 from jaxley.channels import Channel
-from jaxley.solver_gate import solve_gate_exponential
+from jaxley.solver_gate import save_exp, solve_gate_exponential
 
 META = {
     "reference": "Hodgkin, A. L., & Huxley, A. F. (1952). A quantitative description of membrane current and its application to conduction and excitation in nerve. The Journal of Physiology, 117(4), 500–544. https://doi.org/10.1113/jphysiol.1952.sp004764",
@@ -97,15 +97,15 @@ class Na(Channel):
     @staticmethod
     def m_gate(v):
         v += 1e-6
-        alpha = 0.1 * (v + 40) / (1 - jnp.exp(-0.1 * (v + 40)))
-        beta = 4 * jnp.exp(-(v + 65) / 18)
+        alpha = 0.1 * (v + 40) / (1 - save_exp(-0.1 * (v + 40)))
+        beta = 4 * save_exp(-(v + 65) / 18)
         return alpha, beta
 
     @staticmethod
     def h_gate(v):
         v += 1e-6
-        alpha = 0.07 * jnp.exp(-(v + 65) / 20)
-        beta = 1 / (1 + jnp.exp(-0.1 * (v + 35)))
+        alpha = 0.07 * save_exp(-(v + 65) / 20)
+        beta = 1 / (1 + save_exp(-0.1 * (v + 35)))
         return alpha, beta
 
 
@@ -152,8 +152,8 @@ class K(Channel):
     @staticmethod
     def n_gate(v):
         v += 1e-6
-        alpha = 0.01 * (v + 55) / (1 - jnp.exp(-(v + 55) / 10))
-        beta = 0.125 * jnp.exp(-(v + 65) / 80)
+        alpha = 0.01 * (v + 55) / (1 - save_exp(-(v + 55) / 10))
+        beta = 0.125 * save_exp(-(v + 65) / 80)
         return alpha, beta
 
 

--- a/jaxley_mech/channels/l5pc.py
+++ b/jaxley_mech/channels/l5pc.py
@@ -5,6 +5,7 @@ from jax.lax import select
 from jaxley.channels import Channel
 from jaxley.solver_gate import (
     exponential_euler,
+    save_exp,
     solve_gate_exponential,
     solve_inf_gate_exponential,
 )
@@ -92,8 +93,8 @@ class NaTaT(Channel):
     def m_gate(v):
         """Voltage-dependent dynamics for the m gating variable."""
         qt = 2.3 ** ((34 - 21) / 10)
-        alpha = (0.182 * (v + 38 + 1e-6)) / (1 - jnp.exp(-(v + 38 + 1e-6) / 6))
-        beta = (0.124 * (-v - 38 + 1e-6)) / (1 - jnp.exp(-(-v - 38 + 1e-6) / 6))
+        alpha = (0.182 * (v + 38 + 1e-6)) / (1 - save_exp(-(v + 38 + 1e-6) / 6))
+        beta = (0.124 * (-v - 38 + 1e-6)) / (1 - save_exp(-(-v - 38 + 1e-6) / 6))
         m_inf = alpha / (alpha + beta)
         tau_m = 1 / (alpha + beta) / qt
         return m_inf, tau_m
@@ -102,8 +103,8 @@ class NaTaT(Channel):
     def h_gate(v):
         """Voltage-dependent dynamics for the h gating variable."""
         qt = 2.3 ** ((34 - 21) / 10)
-        alpha = (-0.015 * (v + 66 + 1e-6)) / (1 - jnp.exp((v + 66 + 1e-6) / 6))
-        beta = (-0.015 * (-v - 66 + 1e-6)) / (1 - jnp.exp((-v - 66 + 1e-6) / 6))
+        alpha = (-0.015 * (v + 66 + 1e-6)) / (1 - save_exp((v + 66 + 1e-6) / 6))
+        beta = (-0.015 * (-v - 66 + 1e-6)) / (1 - save_exp((-v - 66 + 1e-6) / 6))
         h_inf = alpha / (alpha + beta)
         tau_h = 1 / (alpha + beta) / qt
         return h_inf, tau_h
@@ -170,8 +171,8 @@ class NaTs2T(Channel):
     def m_gate(v):
         """Voltage-dependent dynamics for the m gating variable."""
         qt = 2.3 ** ((34 - 21) / 10)
-        alpha = (0.182 * (v + 32 + 1e-6)) / (1 - jnp.exp(-(v + 32 + 1e-6) / 6))
-        beta = (0.124 * (-v - 32 + 1e-6)) / (1 - jnp.exp(-(-v - 32 + 1e-6) / 6))
+        alpha = (0.182 * (v + 32 + 1e-6)) / (1 - save_exp(-(v + 32 + 1e-6) / 6))
+        beta = (0.124 * (-v - 32 + 1e-6)) / (1 - save_exp(-(-v - 32 + 1e-6) / 6))
         m_inf = alpha / (alpha + beta)
         tau_m = 1 / (alpha + beta) / qt
         return m_inf, tau_m
@@ -180,8 +181,8 @@ class NaTs2T(Channel):
     def h_gate(v):
         """Voltage-dependent dynamics for the h gating variable."""
         qt = 2.3 ** ((34 - 21) / 10)
-        alpha = (-0.015 * (v + 60 + 1e-6)) / (1 - jnp.exp((v + 60 + 1e-6) / 6))
-        beta = (-0.015 * (-v - 60 + 1e-6)) / (1 - jnp.exp((-v - 60 + 1e-6) / 6))
+        alpha = (-0.015 * (v + 60 + 1e-6)) / (1 - save_exp((v + 60 + 1e-6) / 6))
+        beta = (-0.015 * (-v - 60 + 1e-6)) / (1 - save_exp((-v - 60 + 1e-6) / 6))
         h_inf = alpha / (alpha + beta)
         tau_h = 1 / (alpha + beta) / qt
         return h_inf, tau_h
@@ -249,20 +250,20 @@ class NapEt2(Channel):
     def m_gate(v):
         """Voltage-dependent dynamics for the m gating variable."""
         qt = 2.3 ** ((34 - 21) / 10)  # Q10 temperature correction
-        alpha = (0.182 * (v + 38 + 1e-6)) / (1 - jnp.exp(-(v + 38 + 1e-6) / 6))
-        beta = (0.124 * (-v - 38 + 1e-6)) / (1 - jnp.exp(-(-v - 38 + 1e-6) / 6))
+        alpha = (0.182 * (v + 38 + 1e-6)) / (1 - save_exp(-(v + 38 + 1e-6) / 6))
+        beta = (0.124 * (-v - 38 + 1e-6)) / (1 - save_exp(-(-v - 38 + 1e-6) / 6))
         tau_m = 6 / (alpha + beta) / qt
-        m_inf = 1.0 / (1 + jnp.exp((v + 52.7) / -4.6))
+        m_inf = 1.0 / (1 + save_exp((v + 52.7) / -4.6))
         return m_inf, tau_m
 
     @staticmethod
     def h_gate(v):
         """Voltage-dependent dynamics for the h gating variable."""
         qt = 2.3 ** ((34 - 21) / 10)  # Q10 temperature correction
-        alpha = (-2.88e-6 * (v + 17 + 1e-6)) / (1 - jnp.exp((v + 17 + 1e-6) / 4.63))
-        beta = (6.94e-6 * (v + 64.4 + 1e-6)) / (1 - jnp.exp((-(v + 64.4) + 1e-6) / 6))
+        alpha = (-2.88e-6 * (v + 17 + 1e-6)) / (1 - save_exp((v + 17 + 1e-6) / 4.63))
+        beta = (6.94e-6 * (v + 64.4 + 1e-6)) / (1 - save_exp((-(v + 64.4) + 1e-6) / 6))
         tau_h = 1 / (alpha + beta) / qt
-        h_inf = 1.0 / (1 + jnp.exp((v + 48.8) / 10))
+        h_inf = 1.0 / (1 + save_exp((v + 48.8) / 10))
 
         return h_inf, tau_h
 
@@ -333,14 +334,14 @@ class KPst(Channel):
         """Voltage-dependent dynamics for the m gating variable, adjusted for junction potential."""
         qt = 2.3 ** ((34 - 21) / 10)  # Q10 temperature correction
         v_adjusted = v + 10  # Adjust for junction potential
-        m_inf = 1 / (1 + jnp.exp(-(v_adjusted + 1) / 12))
+        m_inf = 1 / (1 + save_exp(-(v_adjusted + 1) / 12))
 
         # See here for documentation of `select` vs `cond`:
         # https://github.com/google/jax/issues/7934
         tau_m = select(
             v_adjusted < jnp.asarray(-50.0),
-            (1.25 + 175.03 * jnp.exp(v_adjusted * 0.026)) / qt,
-            (1.25 + 13 * jnp.exp(-v_adjusted * 0.026)) / qt,
+            (1.25 + 175.03 * save_exp(v_adjusted * 0.026)) / qt,
+            (1.25 + 13 * save_exp(-v_adjusted * 0.026)) / qt,
         )
         return m_inf, tau_m
 
@@ -349,11 +350,11 @@ class KPst(Channel):
         """Voltage-dependent dynamics for the h gating variable, adjusted for junction potential."""
         qt = 2.3 ** ((34 - 21) / 10)  # Q10 temperature correction
         v_adjusted = v + 10  # Adjust for junction potential
-        h_inf = 1 / (1 + jnp.exp(-(v_adjusted + 54) / -11))
+        h_inf = 1 / (1 + save_exp(-(v_adjusted + 54) / -11))
         tau_h = (
             360
             + (1010 + 24 * (v_adjusted + 55))
-            * jnp.exp(-(((v_adjusted + 75) / 48) ** 2))
+            * save_exp(-(((v_adjusted + 75) / 48) ** 2))
         ) / qt
         return h_inf, tau_h
 
@@ -418,8 +419,8 @@ class KTst(Channel):
         """Voltage-dependent dynamics for the m gating variable, adjusted for junction potential."""
         qt = 2.3 ** ((34 - 21) / 10)  # Q10 temperature correction
         v_adjusted = v + 10  # Adjust for junction potential
-        m_inf = 1 / (1 + jnp.exp(-(v_adjusted + 0) / 19))
-        tau_m = (0.34 + 0.92 * jnp.exp(-(((v_adjusted + 71) / 59) ** 2))) / qt
+        m_inf = 1 / (1 + save_exp(-(v_adjusted + 0) / 19))
+        tau_m = (0.34 + 0.92 * save_exp(-(((v_adjusted + 71) / 59) ** 2))) / qt
         return m_inf, tau_m
 
     @staticmethod
@@ -427,8 +428,8 @@ class KTst(Channel):
         """Voltage-dependent dynamics for the h gating variable, adjusted for junction potential."""
         qt = 2.3 ** ((34 - 21) / 10)  # Q10 temperature correction
         v_adjusted = v + 10  # Adjust for junction potential
-        h_inf = 1 / (1 + jnp.exp(-(v_adjusted + 66) / -10))
-        tau_h = (8 + 49 * jnp.exp(-(((v_adjusted + 73) / 23) ** 2))) / qt
+        h_inf = 1 / (1 + save_exp(-(v_adjusted + 66) / -10))
+        tau_h = (8 + 49 * save_exp(-(((v_adjusted + 73) / 23) ** 2))) / qt
         return h_inf, tau_h
 
 
@@ -547,8 +548,8 @@ class SKv3_1(Channel):
     @staticmethod
     def m_gate(v):
         """Voltage-dependent dynamics for the m gating variable."""
-        m_inf = 1 / (1 + jnp.exp((v - 18.7) / -9.7))
-        tau_m = 0.2 * 20.0 / (1 + jnp.exp((v + 46.56) / -44.14))
+        m_inf = 1 / (1 + save_exp((v - 18.7) / -9.7))
+        tau_m = 0.2 * 20.0 / (1 + save_exp((v + 46.56) / -44.14))
         return m_inf, tau_m
 
 
@@ -605,8 +606,8 @@ class M(Channel):
     def m_gate(v):
         """Voltage-dependent dynamics for the m gating variable, with temperature correction."""
         qt = 2.3 ** ((34 - 21) / 10)  # Q10 temperature correction
-        m_alpha = 3.3e-3 * jnp.exp(2.5 * 0.04 * (v + 35))
-        m_beta = 3.3e-3 * jnp.exp(-2.5 * 0.04 * (v + 35))
+        m_alpha = 3.3e-3 * save_exp(2.5 * 0.04 * (v + 35))
+        m_beta = 3.3e-3 * save_exp(-2.5 * 0.04 * (v + 35))
         m_inf = m_alpha / (m_alpha + m_beta)
         tau_m = (1 / (m_alpha + m_beta)) / qt
         return m_inf, tau_m
@@ -674,15 +675,15 @@ class CaHVA(Channel):
     @staticmethod
     def m_gate(v):
         """Voltage-dependent dynamics for the m gating variable."""
-        alpha = (0.055 * (-27 - v + 1e-6)) / (jnp.exp((-27.0 - v + 1e-6) / 3.8) - 1.0)
-        beta = 0.94 * jnp.exp((-75.0 - v + 1e-6) / 17.0)
+        alpha = (0.055 * (-27 - v + 1e-6)) / (save_exp((-27.0 - v + 1e-6) / 3.8) - 1.0)
+        beta = 0.94 * save_exp((-75.0 - v + 1e-6) / 17.0)
         return alpha, beta
 
     @staticmethod
     def h_gate(v):
         """Voltage-dependent dynamics for the h gating variable."""
-        alpha = 0.000457 * jnp.exp((-13.0 - v) / 50.0)
-        beta = 0.0065 / (jnp.exp((-v - 15.0) / 28.0) + 1.0)
+        alpha = 0.000457 * save_exp((-13.0 - v) / 50.0)
+        beta = 0.0065 / (save_exp((-v - 15.0) / 28.0) + 1.0)
         return alpha, beta
 
 
@@ -744,8 +745,8 @@ class CaLVA(Channel):
         """Voltage-dependent dynamics for the m gating variable, adjusted for junction potential."""
         qt = 2.3 ** ((34 - 21) / 10)  # Q10 temperature correction
         v_shifted = v + 10  # Shift by 10 mV
-        m_inf = 1.0 / (1 + jnp.exp((v_shifted + 30) / -6))
-        tau_m = (5.0 + 20.0 / (1 + jnp.exp((v_shifted + 25) / 5))) / qt
+        m_inf = 1.0 / (1 + save_exp((v_shifted + 30) / -6))
+        tau_m = (5.0 + 20.0 / (1 + save_exp((v_shifted + 25) / 5))) / qt
         return m_inf, tau_m
 
     @staticmethod
@@ -753,8 +754,8 @@ class CaLVA(Channel):
         """Voltage-dependent dynamics for the h gating variable, adjusted for junction potential."""
         qt = 2.3 ** ((34 - 21) / 10)  # Q10 temperature correction
         v_shifted = v + 10  # Shift by 10 mV
-        h_inf = 1.0 / (1 + jnp.exp((v_shifted + 80) / 6.4))
-        tau_h = (20.0 + 50.0 / (1 + jnp.exp((v_shifted + 40) / 7))) / qt
+        h_inf = 1.0 / (1 + save_exp((v_shifted + 80) / 6.4))
+        tau_h = (20.0 + 50.0 / (1 + save_exp((v_shifted + 40) / 7))) / qt
         return h_inf, tau_h
 
 
@@ -908,9 +909,12 @@ class H(Channel):
     def m_gate(v):
         """Voltage-dependent dynamics for the m gating variable."""
         m_alpha = (
-            0.001 * 6.43 * (v + 154.9 + 1e-6) / (jnp.exp((v + 154.9 + 1e-6) / 11.9) - 1)
+            0.001
+            * 6.43
+            * (v + 154.9 + 1e-6)
+            / (save_exp((v + 154.9 + 1e-6) / 11.9) - 1)
         )
-        m_beta = 0.001 * 193 * jnp.exp(v / 33.1)
+        m_beta = 0.001 * 193 * save_exp(v / 33.1)
         m_inf = m_alpha / (m_alpha + m_beta)
         tau_m = 1 / (m_alpha + m_beta)
         return m_inf, tau_m

--- a/jaxley_mech/synapses/dms98.py
+++ b/jaxley_mech/synapses/dms98.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional
 
 import jax.numpy as jnp
 from jax.lax import select
+from jaxley.solver_gate import save_exp
 from jaxley.synapses import Synapse
 
 __all__ = ["AMPA", "GABAa", "GABAb", "NMDA"]
@@ -451,9 +452,9 @@ class NMDA(Synapse):
     @staticmethod
     def mgblock(v, mg_concentration):
         """Magnesium block factor."""
-        return 1 / (1 + jnp.exp(0.062 * (-v)) * (mg_concentration / 3.57))
+        return 1 / (1 + save_exp(0.062 * (-v)) * (mg_concentration / 3.57))
 
 
 def exptable(x):
     """Approximate exponential function used in NEURON's AMPA model."""
-    return select((x > -10) & (x < 10), jnp.exp(x), jnp.asarray([0.0]))
+    return select((x > -10) & (x < 10), save_exp(x), jnp.asarray([0.0]))

--- a/jaxley_mech/synapses/ribbon.py
+++ b/jaxley_mech/synapses/ribbon.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+from jaxley.solver_gate import save_exp
 from jaxley.synapses.synapse import Synapse
 
 
@@ -46,7 +47,7 @@ class RibbonSynapse(Synapse):
         V_half = -35
 
         # Presynaptic voltage to calcium to release probability
-        p_d_t = 1 / (1 + jnp.exp(-k * (pre_voltage - V_half)))
+        p_d_t = 1 / (1 + save_exp(-k * (pre_voltage - V_half)))
 
         # Vesicle release (NOTE: p_d_t is the mean of the beta distribution)
         new_released = p_d_t * u["docked"]
@@ -60,7 +61,7 @@ class RibbonSynapse(Synapse):
         new_ribboned = jnp.maximum(new_ribboned, params["R_max"])
 
         P_rel = new_released / params["D_max"]
-        P_s = jnp.exp(-delta_t / params["tau"])
+        P_s = save_exp(-delta_t / params["tau"])
 
         return {
             "released": new_released,

--- a/jaxley_mech/utils.py
+++ b/jaxley_mech/utils.py
@@ -1,6 +1,7 @@
 import jax.numpy as jnp
+from jaxley.solver_gate import save_exp
 
 
 def efun(x, y):
     x += 1e-9
-    return x / (jnp.exp(x / y) - 1.0)
+    return x / (save_exp(x / y) - 1.0)

--- a/notebooks/channels/fm97.ipynb
+++ b/notebooks/channels/fm97.ipynb
@@ -378,7 +378,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Last updated: 2024-04-04 11:27:02CEST\n",
+      "Last updated: 2024-04-08 10:26:59CEST\n",
       "\n",
       "Python implementation: CPython\n",
       "Python version       : 3.10.13\n",
@@ -387,8 +387,8 @@
       "jaxley_mech: 0.0.1\n",
       "\n",
       "jax       : 0.4.26\n",
-      "matplotlib: 3.8.3\n",
       "jaxley    : 0.0.0\n",
+      "matplotlib: 3.8.3\n",
       "\n",
       "Watermark: 2.4.3\n",
       "\n"

--- a/notebooks/channels/hh.ipynb
+++ b/notebooks/channels/hh.ipynb
@@ -209,7 +209,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Last updated: 2024-04-04 11:27:15CEST\n",
+      "Last updated: 2024-04-08 10:26:38CEST\n",
       "\n",
       "Python implementation: CPython\n",
       "Python version       : 3.10.13\n",
@@ -217,9 +217,9 @@
       "\n",
       "jaxley_mech: 0.0.1\n",
       "\n",
-      "jax       : 0.4.26\n",
-      "matplotlib: 3.8.3\n",
       "jaxley    : 0.0.0\n",
+      "matplotlib: 3.8.3\n",
+      "jax       : 0.4.26\n",
       "\n",
       "Watermark: 2.4.3\n",
       "\n"

--- a/notebooks/channels/l5pc.ipynb
+++ b/notebooks/channels/l5pc.ipynb
@@ -252,7 +252,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Last updated: 2024-04-04 11:42:10CEST\n",
+      "Last updated: 2024-04-08 10:27:50CEST\n",
       "\n",
       "Python implementation: CPython\n",
       "Python version       : 3.10.13\n",
@@ -261,8 +261,8 @@
       "jaxley_mech: 0.0.1\n",
       "\n",
       "jaxley    : 0.0.0\n",
-      "matplotlib: 3.8.3\n",
       "jax       : 0.4.26\n",
+      "matplotlib: 3.8.3\n",
       "\n",
       "Watermark: 2.4.3\n",
       "\n"

--- a/notebooks/synapses/dms98.ipynb
+++ b/notebooks/synapses/dms98.ipynb
@@ -110,7 +110,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/ziweih/Works/retimod/jaxley/jaxley/modules/base.py:1349: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
+      "/Users/ziweih/Works/retimod/jaxley/jaxley/modules/base.py:1346: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
       "  self.pointer.edges = pd.concat(\n"
      ]
     }
@@ -244,7 +244,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/ziweih/Works/retimod/jaxley/jaxley/modules/base.py:1349: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
+      "/Users/ziweih/Works/retimod/jaxley/jaxley/modules/base.py:1346: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
       "  self.pointer.edges = pd.concat(\n"
      ]
     }
@@ -382,7 +382,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/ziweih/Works/retimod/jaxley/jaxley/modules/base.py:1349: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
+      "/Users/ziweih/Works/retimod/jaxley/jaxley/modules/base.py:1346: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
       "  self.pointer.edges = pd.concat(\n"
      ]
     }
@@ -508,7 +508,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/ziweih/Works/retimod/jaxley/jaxley/modules/base.py:1349: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
+      "/Users/ziweih/Works/retimod/jaxley/jaxley/modules/base.py:1346: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.\n",
       "  self.pointer.edges = pd.concat(\n"
      ]
     }
@@ -638,7 +638,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Last updated: 2024-04-04 15:43:58CEST\n",
+      "Last updated: 2024-04-08 10:25:29CEST\n",
       "\n",
       "Python implementation: CPython\n",
       "Python version       : 3.10.13\n",


### PR DESCRIPTION
change: `jnp.exp` to `save_exp` according to jaxleyverse/jaxley #319

@kyralianaka I hit some errors when running the ribbon and gap junction notebooks, likely due to changes in jaxley in the past few weeks. Can you fix them and push to this pull request? 