### PR TITLE
add `init_states` to CaPump

### DIFF
--- a/jaxley_mech/channels/fm97.py
+++ b/jaxley_mech/channels/fm97.py
@@ -369,6 +369,10 @@ class CaPump(Channel):
     def compute_current(self, states, v, params):
         """The pump does not directly contribute to the membrane current."""
         return 0
+    
+    def init_state(self, voltages, params):
+        """Initialize the state at fixed point of gate dynamics."""
+        return {}
 
 
 class KCa(Channel):


### PR DESCRIPTION
Quick fix for CaPump `init_states`. In the long run, we could add this empty `init_states` to the `Channel` base class.