### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
This PR removes ipython notebook from the github language tracking (such that the code-base will be listed as `python`, not as `jupyter`).